### PR TITLE
feat: replace NEXT_PUBLIC_BE_URL with server-side proxy for backend API calls

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,5 +1,5 @@
 NEXT_PUBLIC_BASE_PATH="/popisujeme" # e.g. /popisujeme for subpath deployments, empty for root local run
-BE_URL="http://localhost:8081/popisujeme" # server-side only, never exposed to client. Next.js proxies /api/backend/* requests to BE_URL/api/*.
+BE_URL="http://127.0.0.1:8081/popisujeme" # server-side only, never exposed to client. Next.js proxies /api/backend/* requests to BE_URL/api/*.
 KEYCLOAK_CLIENT_ID=""
 KEYCLOAK_CLIENT_SECRET=""
 KEYCLOAK_ISSUER=""

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,7 +1,7 @@
-NEXT_PUBLIC_BE_URL=""
-NEXT_PUBLIC_BASE_PATH="" # e.g. /popisujeme for subpath deployments, empty for root local run
+NEXT_PUBLIC_BASE_PATH="/popisujeme" # e.g. /popisujeme for subpath deployments, empty for root local run
+BE_URL="http://localhost:8081/popisujeme" # server-side only, never exposed to client. Next.js proxies /api/backend/* requests to BE_URL/api/*.
 KEYCLOAK_CLIENT_ID=""
 KEYCLOAK_CLIENT_SECRET=""
 KEYCLOAK_ISSUER=""
-NEXTAUTH_URL=""
-NEXTAUTH_SECRET="" # Added by `npx auth`. Read more: https://cli.authjs.dev
+NEXTAUTH_URL="http://localhost:3000/popisujeme/api/auth"
+NEXTAUTH_SECRET="secret"

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,8 @@ WORKDIR /app
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
 
-# Default backend URL for Docker environments
-# Can be overridden at runtime with docker run -e NEXT_PUBLIC_BE_URL=...
-# (Works at runtime due to publicRuntimeConfig in next.config.mjs)
-ENV NEXT_PUBLIC_BE_URL=http://host.docker.internal:8080
+# Backend URL for proxying API requests (server-side only, safe to set at runtime)
+ENV BE_URL=http://host.docker.internal:8081/popisujeme
 
 # Copy package files
 COPY --from=build /app/package.json ./

--- a/src/app/api/backend/[...path]/route.ts
+++ b/src/app/api/backend/[...path]/route.ts
@@ -3,11 +3,6 @@ import { getServerSession } from 'next-auth';
 
 import { authOptions } from '@/lib/auth';
 
-const BE_URL = process.env.BE_URL;
-if (!BE_URL) {
-  throw new Error('BE_URL environment variable is required');
-}
-
 const HOP_BY_HOP = new Set([
   'transfer-encoding',
   'connection',
@@ -28,6 +23,11 @@ async function handler(
 
   if (joined.includes('..') || /[/\\]/.test(path[0] ?? '')) {
     return new NextResponse('Bad request', { status: 400 });
+  }
+
+  const BE_URL = process.env.BE_URL;
+  if (!BE_URL) {
+    return new NextResponse('BE_URL not configured', { status: 500 });
   }
 
   const targetUrl = `${BE_URL}/${joined}${req.nextUrl.search}`;

--- a/src/app/api/backend/[...path]/route.ts
+++ b/src/app/api/backend/[...path]/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+
+import { authOptions } from '@/lib/auth';
+
+const BE_URL = process.env.BE_URL;
+if (!BE_URL) {
+  throw new Error('BE_URL environment variable is required');
+}
+
+const HOP_BY_HOP = new Set([
+  'transfer-encoding',
+  'connection',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'upgrade',
+]);
+
+async function handler(
+  req: NextRequest,
+  { params }: { params: Promise<{ path: string[] }> },
+) {
+  const { path } = await params;
+  const joined = path.join('/');
+
+  if (joined.includes('..') || /[/\\]/.test(path[0] ?? '')) {
+    return new NextResponse('Bad request', { status: 400 });
+  }
+
+  const targetUrl = `${BE_URL}/api/${joined}${req.nextUrl.search}`;
+
+  const session = await getServerSession(authOptions);
+
+  const headers = new Headers();
+  const contentType = req.headers.get('Content-Type');
+  if (contentType) {
+    headers.set('Content-Type', contentType);
+  }
+  const accept = req.headers.get('Accept');
+  if (accept) {
+    headers.set('Accept', accept);
+  }
+  if (session?.accessToken) {
+    headers.set('Authorization', `Bearer ${session.accessToken}`);
+  }
+
+  const response = await fetch(targetUrl, {
+    method: req.method,
+    headers,
+    body: req.method !== 'GET' && req.method !== 'HEAD' ? req.body : undefined,
+    // @ts-expect-error - duplex is required for streaming request bodies
+    duplex: 'half',
+  });
+
+  const responseHeaders = new Headers();
+  response.headers.forEach((value, key) => {
+    if (!HOP_BY_HOP.has(key.toLowerCase())) {
+      responseHeaders.set(key, value);
+    }
+  });
+
+  return new NextResponse(response.body, {
+    status: response.status,
+    headers: responseHeaders,
+  });
+}
+
+export const GET = handler;
+export const POST = handler;
+export const PUT = handler;
+export const PATCH = handler;
+export const DELETE = handler;

--- a/src/app/api/backend/[...path]/route.ts
+++ b/src/app/api/backend/[...path]/route.ts
@@ -30,7 +30,7 @@ async function handler(
     return new NextResponse('Bad request', { status: 400 });
   }
 
-  const targetUrl = `${BE_URL}/api/${joined}${req.nextUrl.search}`;
+  const targetUrl = `${BE_URL}/${joined}${req.nextUrl.search}`;
 
   const session = await getServerSession(authOptions);
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,6 @@ export const metadata: Metadata = {
 const loadEnvVariables = () => {
   // define any variables to be loaded on the node server to be passed to the client
   return {
-    NEXT_PUBLIC_BE_URL: process.env.NEXT_PUBLIC_BE_URL ?? undefined,
     NEXT_PUBLIC_BASE_PATH: process.env.NEXT_PUBLIC_BASE_PATH ?? undefined,
     environment: process.env.environment ?? 'development',
   };

--- a/src/axios-instance.ts
+++ b/src/axios-instance.ts
@@ -1,20 +1,12 @@
 import Axios, { AxiosRequestConfig } from 'axios';
-import { getSession } from 'next-auth/react';
 
 export const AXIOS_INSTANCE = Axios.create({
-  baseURL: process.env.NEXT_PUBLIC_BE_URL,
+  baseURL: `${process.env.NEXT_PUBLIC_BASE_PATH ?? ''}/api/backend`,
   withCredentials: false,
 });
 
-AXIOS_INSTANCE.interceptors.request.use(async (config) => {
-  if (typeof window !== 'undefined') {
-    const session = await getSession();
-    if (session?.accessToken) {
-      config.headers.Authorization = `Bearer ${session.accessToken}`;
-    }
-  }
-  return config;
-});
+// Auth is handled server-side by the /api/backend proxy route.
+// No token attachment needed here.
 
 AXIOS_INSTANCE.interceptors.response.use(
   (response) => response,

--- a/src/components/contexts/Environment.tsx
+++ b/src/components/contexts/Environment.tsx
@@ -3,13 +3,9 @@ import React, {
   PropsWithChildren,
   ReactNode,
   useContext,
-  useEffect,
 } from 'react';
 
-import { AXIOS_INSTANCE } from '@/axios-instance';
-
 export type EnvironmentVariables = {
-  NEXT_PUBLIC_BE_URL?: string;
   NEXT_PUBLIC_BASE_PATH?: string;
   environment: string;
 };
@@ -40,13 +36,6 @@ export default function Environment({
   children,
   variables,
 }: PropsWithChildren<EnvironmentProps>): ReactNode {
-  // Update axios baseURL when variables change
-  useEffect(() => {
-    if (variables.NEXT_PUBLIC_BE_URL) {
-      AXIOS_INSTANCE.defaults.baseURL = variables.NEXT_PUBLIC_BE_URL;
-    }
-  }, [variables.NEXT_PUBLIC_BE_URL]);
-
   return (
     <EnvironmentContext.Provider value={{ variables }}>
       {children}

--- a/src/components/header/hintSidebox/HintSidebox.tsx
+++ b/src/components/header/hintSidebox/HintSidebox.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl';
 import ReactMarkdown from 'react-markdown';
 
 import { FileNode, SearchMatchType } from '@/lib/appTypes';
+import { fetchApi } from '@/lib/basePath';
 import { useHintboxStore } from '@/store/hintboxStore';
 import { Searchbar } from '../../shared/Searchbar';
 import { Sidebox } from '../../shared/Sidebox';
@@ -34,7 +35,7 @@ export const HintSidebox = () => {
       setTree(JSON.parse(cachedTree));
     }
 
-    fetch('/api/hint-tree')
+    fetchApi('/api/hint-tree')
       .then((res) => res.json())
       .then((data) => {
         setTree(data);
@@ -53,7 +54,7 @@ export const HintSidebox = () => {
 
     const id = setTimeout(async () => {
       try {
-        const res = await fetch(
+        const res = await fetchApi(
           `/api/hint-search?q=${encodeURIComponent(searchQuery)}`,
         );
         const data: { matches: SearchMatchType[] } = await res.json();
@@ -91,7 +92,7 @@ export const HintSidebox = () => {
       setFileContent(cachedContent);
     }
 
-    fetch(`/api/hint-file?filePath=${encodeURIComponent(path)}`)
+    fetchApi(`/api/hint-file?filePath=${encodeURIComponent(path)}`)
       .then((res) => res.json())
       .then((data) => {
         setFileContent(data.content);

--- a/src/components/home/NewsSidebar.tsx
+++ b/src/components/home/NewsSidebar.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 
+import { fetchApi } from '@/lib/basePath';
 import { BlogPost } from '@/lib/blogs';
 import { SidebarContainer } from '../shared/SidebarContainer';
 
@@ -18,7 +19,7 @@ export function NewsSidebar() {
       setBlogPosts(JSON.parse(cached));
     }
 
-    fetch('/api/blogs')
+    fetchApi('/api/blogs')
       .then((res) => res.json())
       .then((data) => {
         setBlogPosts(data);

--- a/src/lib/basePath.ts
+++ b/src/lib/basePath.ts
@@ -8,3 +8,8 @@ export const normalizeBasePath = (basePath?: string): string => {
     ? withLeadingSlash.slice(0, -1)
     : withLeadingSlash;
 };
+
+const basePath = normalizeBasePath(process.env.NEXT_PUBLIC_BASE_PATH);
+
+export const fetchApi = (path: string, init?: RequestInit): Promise<Response> =>
+  fetch(`${basePath}${path}`, init);


### PR DESCRIPTION
### Summary

  - Introduces a Next.js API proxy route at src/app/api/backend/[...path] that
  forwards all backend API calls server-side, attaching the session JWT via
  getServerSession - the backend URL and auth tokens are no longer exposed to the
  browser
  - Replaces NEXT_PUBLIC_BE_URL with BE_URL (server-side only env var, safe to set at
  container startup)
  - Removes the client-side getSession() Axios interceptor - auth is now handled
  entirely by the proxy
  - Adds fetchApi helper to basePath.ts so bare /api/* calls in HintSidebox and
  NewsSidebar correctly prepend the base path when running under /popisujeme
  - Updates Dockerfile and .env.local.example to reflect the new variable names
  with working local defaults

  ### Infrastructure dependency

  The App Gateway tool-api-rule must be updated from /popisujeme/be/api/* → backend pool to /popisujeme/api/* → frontend pool after this is deployed. This consolidates all Next.js API routes (auth, backend proxy, internal hint/blog routes) under one rule and removes the now-redundant tool-nextauth-rule. The change is ready in infrastructure/modules/shared_global/appgw_tool_config.tf but must not be applied until the new frontend image is live - applying it before would break all API calls since the current frontend has no proxy route.