### PR TITLE
fix(tool-frontend): route swagger through BFF proxy, strip X-Frame-Options

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,5 +1,5 @@
 NEXT_PUBLIC_BASE_PATH="/popisujeme" # e.g. /popisujeme for subpath deployments, empty for root local run
-BE_URL="http://127.0.0.1:8081/popisujeme" # server-side only, never exposed to client. Next.js proxies /api/backend/* requests to BE_URL/api/*.
+BE_URL="http://host.docker.internal:8081/popisujeme" # server-side only, never exposed to client. Use host.docker.internal (not localhost/127.0.0.1) — works whether npm run dev runs in WSL, PowerShell, or Git Bash, and whether the backend is in Docker or IDEA.
 KEYCLOAK_CLIENT_ID=""
 KEYCLOAK_CLIENT_SECRET=""
 KEYCLOAK_ISSUER=""

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,20 +11,18 @@ const nextConfig: NextConfig = {
   },
   async rewrites() {
     return [
+      // Swagger / OpenAPI paths route through /api/backend so the proxy can
+      // strip Spring Boot's X-Frame-Options: DENY (would otherwise block the
+      // iframe). The handler skips auth for these paths so swagger works even
+      // when Keycloak is not running.
       { source: '/v3/api-docs', destination: '/api/backend/v3/api-docs' },
       {
         source: '/v3/api-docs/:path*',
         destination: '/api/backend/v3/api-docs/:path*',
       },
-      { source: '/swagger-ui', destination: '/api/backend/swagger-ui' },
       {
         source: '/swagger-ui/:path*',
         destination: '/api/backend/swagger-ui/:path*',
-      },
-      { source: '/api-docs', destination: '/api/backend/api-docs' },
-      {
-        source: '/api-docs/:path*',
-        destination: '/api/backend/api-docs/:path*',
       },
     ];
   },

--- a/src/app/api-docs/page.tsx
+++ b/src/app/api-docs/page.tsx
@@ -1,0 +1,18 @@
+const BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH || '/popisujeme';
+
+export default function ApiDocsPage() {
+  return (
+    <iframe
+      src={`${BASE_PATH}/swagger-ui/index.html`}
+      title="API documentation"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        border: 0,
+        width: '100%',
+        height: '100%',
+        zIndex: 9999,
+      }}
+    />
+  );
+}

--- a/src/app/api/backend/[...path]/route.ts
+++ b/src/app/api/backend/[...path]/route.ts
@@ -12,6 +12,10 @@ const HOP_BY_HOP = new Set([
   'te',
   'trailer',
   'upgrade',
+  // Strip framing headers — Next.js owns the frame policy at the outer layer.
+  // Without this, Spring Boot's default X-Frame-Options: DENY blocks the
+  // swagger-ui iframe on /api-docs.
+  'x-frame-options',
 ]);
 
 async function handler(
@@ -32,7 +36,15 @@ async function handler(
 
   const targetUrl = `${BE_URL}/${joined}${req.nextUrl.search}`;
 
-  const session = await getServerSession(authOptions);
+  // Swagger and OpenAPI paths are public — skip the session lookup so swagger
+  // works even when Keycloak is not running locally. NextAuth lazily fetches
+  // the OIDC discovery doc on first getServerSession, which hangs without it.
+  const isPublicDocsPath =
+    joined.startsWith('swagger-ui') ||
+    joined.startsWith('api-docs') ||
+    joined.startsWith('v3/api-docs');
+
+  const session = isPublicDocsPath ? null : await getServerSession(authOptions);
 
   const headers = new Headers();
   const contentType = req.headers.get('Content-Type');


### PR DESCRIPTION
Swagger UI was returning 500 because Spring Security's default X-Frame-Options: DENY blocked the iframe and getServerSession() hung when Keycloak wasn't running locally.

- api/backend/[...path]/route.ts: add x-frame-options to the hop-by-hop set so the proxy strips it before responding; skip getServerSession() for swagger-ui, api-docs, and v3/api-docs paths so docs load without Keycloak
- next.config.ts: rewrite /v3/api-docs/* and /swagger-ui/* through /api/backend so the route handler runs on every swagger asset
- add /api-docs page with a fullscreen iframe pointing at swagger-ui
- .env.local.example: document host.docker.internal for BE_URL