### PR TITLE
feat(coming-soon): strip header/footer on gated pages

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import '../styles/globals.css';
 
 import { ReactNode } from 'react';
 import type { Metadata } from 'next';
+import { headers } from 'next/headers';
 import Script from 'next/script';
 import { getServerSession } from 'next-auth';
 import { NextIntlClientProvider } from 'next-intl';
@@ -13,6 +14,7 @@ import type { EnvironmentVariables } from '@/components/contexts/Environment';
 import { Footer } from '@/components/footer/Footer';
 import { Header } from '@/components/header/Header';
 import { authOptions } from '@/lib/auth';
+import { GATED_REQUEST_HEADER } from '@/lib/site-status';
 
 import Providers from './providers';
 
@@ -36,6 +38,8 @@ export default async function RootLayout({
   const locale = await getLocale();
   const messages = await getMessages();
   const session = await getServerSession(authOptions);
+  const requestHeaders = await headers();
+  const isGated = requestHeaders.get(GATED_REQUEST_HEADER) === '1';
 
   const variables: EnvironmentVariables = {
     ...loadEnvVariables(),
@@ -51,10 +55,10 @@ export default async function RootLayout({
         </Script>
         <NextIntlClientProvider locale={locale} messages={messages}>
           <Providers environmentVariables={variables} session={session}>
-            <Header session={session} />
+            <Header session={session} isGated={isGated} />
             {children}
           </Providers>
-          <Footer />
+          <Footer isGated={isGated} />
         </NextIntlClientProvider>
       </body>
     </html>

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -7,8 +7,53 @@ import { scrollTop } from '@/lib/windowUtils';
 
 import { FooterColumn } from './FooterColumn';
 
-export const Footer = () => {
+interface Props {
+  isGated?: boolean;
+}
+
+export const Footer = ({ isGated = false }: Props) => {
   const t = useTranslations('Footer');
+
+  if (isGated) {
+    return (
+      <footer className="bg-blue py-12 text-white mt-auto">
+        <section className="max-w-desktop px-5 mx-auto space-y-12">
+          <div className="space-y-4">
+            <h5 className="font-medium text-xl">{t('ContactColumn.Title')}</h5>
+            <GovLink href={`mailto:${t('ContactColumn.Email')}`} size="s">
+              <GovIcon slot="icon-start" name="envelope" />
+              {t('ContactColumn.Email')}
+            </GovLink>
+          </div>
+          <div className="space-y-4">
+            <h6 className="text-lg font-medium">{t('ThanksSection.Title')}</h6>
+            <p className="text-sm">{t('ThanksSection.Text')}</p>
+            <ul className="flex gap-y-4 gap-x-6 flex-wrap">
+              <li>
+                <GovIcon name="logo-eu" />
+              </li>
+              <li>
+                <GovIcon name="logo-npo" />
+              </li>
+              <li>
+                <GovIcon name="logo-dia" />
+              </li>
+            </ul>
+          </div>
+          <div className="space-y-4">
+            <hr className="!border-t-footer-separator" />
+            <div className="flex justify-between flex-wrap gap-y-4 gap-x-8 text-secondary text-xs">
+              <p>{t('FooterCopySection.Copyright')}</p>
+              <div className="flex gap-x-3">
+                <p>{t('FooterCopySection.Version')}</p>|
+                <p>{t('FooterCopySection.DesignSystem')}</p>
+              </div>
+            </div>
+          </div>
+        </section>
+      </footer>
+    );
+  }
 
   return (
     <footer className="bg-blue py-12 text-white mt-auto">

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -22,9 +22,10 @@ import { NavItems } from './NavItems';
 
 interface Props {
   session: Session | null;
+  isGated?: boolean;
 }
 
-export const Header = ({ session }: Props) => {
+export const Header = ({ session, isGated: isGatedProp }: Props) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const t = useTranslations('Header');
 
@@ -36,7 +37,7 @@ export const Header = ({ session }: Props) => {
 
   const isHomepage = pathname === '/';
   const showFullHeader = !isHomepage || !!session;
-  const isGated = isGatedPath(pathname);
+  const isGated = isGatedProp ?? isGatedPath(pathname);
 
   const handleLogin = () =>
     signIn('keycloak', { prompt: 'login', callbackUrl });

--- a/src/lib/site-status.ts
+++ b/src/lib/site-status.ts
@@ -38,3 +38,8 @@ export function parseSiteStatus(value: string | undefined): SiteStatus {
 export function isGatedPath(pathname: string): boolean {
   return pathname === COMING_SOON_PATH || pathname === MAINTENANCE_PATH;
 }
+
+// Header set by middleware on gated requests so server components (layout)
+// can detect the gated state without depending on usePathname, which returns
+// the original (un-rewritten) pathname on the client after NextResponse.rewrite.
+export const GATED_REQUEST_HEADER = 'x-site-gated';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,12 +5,19 @@ import {
   BYPASS_QUERY_PARAM,
   BYPASS_QUERY_VALUE_DISABLE,
   COMING_SOON_PATH,
+  GATED_REQUEST_HEADER,
   getPreviewSecret,
   MAINTENANCE_PATH,
   parseSiteStatus,
 } from '@/lib/site-status';
 
 const BYPASS_MAX_AGE_SECONDS = 60 * 60 * 24 * 30;
+
+function gatedRequestHeaders(request: NextRequest): Headers {
+  const headers = new Headers(request.headers);
+  headers.set(GATED_REQUEST_HEADER, '1');
+  return headers;
+}
 
 export function middleware(request: NextRequest) {
   const { pathname, searchParams } = request.nextUrl;
@@ -55,9 +62,12 @@ export function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // Allow already on gated pages so the rewrite target itself can render
+  // Direct visit to a gated page — allow through but flag it so the layout
+  // renders the stripped header/footer regardless of the original pathname.
   if (pathname === COMING_SOON_PATH || pathname === MAINTENANCE_PATH) {
-    return NextResponse.next();
+    return NextResponse.next({
+      request: { headers: gatedRequestHeaders(request) },
+    });
   }
 
   // Bypass cookie holders see the live app. Cookie value must match the
@@ -75,7 +85,9 @@ export function middleware(request: NextRequest) {
   const url = request.nextUrl.clone();
   url.pathname = gatedPath;
   url.search = '';
-  return NextResponse.rewrite(url);
+  return NextResponse.rewrite(url, {
+    request: { headers: gatedRequestHeaders(request) },
+  });
 }
 
 export const config = {


### PR DESCRIPTION
usePathname() returns the original URL after NextResponse.rewrite, so the client-side isGatedPath() check missed the rewritten coming-soon / maintenance pages and the full header/footer kept rendering.

Middleware now sets x-site-gated: 1 on the request when rewriting (and on direct visits to gated paths). The root layout reads it server-side and passes isGated to Header and Footer, which render minimal versions:

- Header: logo only, no nav / login / theme switch / help / feedback
- Footer: contact + thanks section + copyright; drops GitHub link, placeholder Link1/Link2, and the four bottom placeholder links