### PR TITLE
chore(docker): parametrize build context via TOOL_FRONTEND_PATH

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -6,7 +6,10 @@ services:
     image: ismd-tool-frontend:local
     pull_policy: never
     build:
-      context: .
+      # Default `.` works when running from this directory directly.
+      # When composed from ismd-infrastructure via `-f`, set TOOL_FRONTEND_PATH
+      # to the path of this repo (e.g. ../ismd-tool-frontend).
+      context: ${TOOL_FRONTEND_PATH:-.}
       args:
         NODE_ENV: ${NODE_ENV:-development}
         NEXT_PUBLIC_BASE_PATH: ${NEXT_PUBLIC_BASE_PATH:-/popisujeme}


### PR DESCRIPTION
Same pattern as the backends — default `.` preserves standalone use; supports cross-repo composition from ismd-infrastructure.