### PR TITLE
fix: stop 5xx on hint API routes and ship hint content in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,9 @@ COPY --from=build /app/.next ./.next
 COPY --from=build /app/public ./public
 COPY --from=build /app/next.config.ts ./
 COPY --from=build /app/messages ./messages
+# Hint API routes read these markdown files from disk at runtime via
+# process.cwd()/src/app/hints, so the source content must ship in the image.
+COPY --from=build /app/src/app/hints ./src/app/hints
 
 EXPOSE 3000
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,15 +2,23 @@ import createMDX from '@next/mdx';
 import { NextConfig } from 'next';
 import createNextIntlPlugin from 'next-intl/plugin';
 
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH ?? '/popisujeme';
+
 const nextConfig: NextConfig = {
   output: 'standalone',
-  basePath: process.env.NEXT_PUBLIC_BASE_PATH ?? '/popisujeme',
+  basePath,
   pageExtensions: ['ts', 'tsx', 'mdx'],
   experimental: {
     mdxRs: true,
   },
   async rewrites() {
     return [
+      // NOTE: the root /favicon.ico 404 (browsers probe the origin root,
+      // ignoring basePath) is intentionally NOT handled here. A basePath:false
+      // rewrite back into the basePath is rejected by Next (requires an
+      // absolute external URL), and in prod the root request never reaches Next
+      // anyway — the client nginx edge / AppGW default-redirect-to-/validujeme
+      // own it. Accepted tech debt.
       // Swagger / OpenAPI paths route through /api/backend so the proxy can
       // strip Spring Boot's X-Frame-Options: DENY (would otherwise block the
       // iframe). The handler skips auth for these paths so swagger works even

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,10 +1,14 @@
 const CACHE_NAME = 'ismd-tool-v1';
 
+// Derive the app base path from the registration scope (e.g. "/popisujeme")
+// so the worker works whether or not a Next.js basePath is set.
+const BASE = new URL(self.registration.scope).pathname.replace(/\/$/, '');
+
 self.addEventListener('install', (event) => {
   self.skipWaiting();
   event.waitUntil(
     caches.open(CACHE_NAME).then((cache) => {
-      return cache.add('/');
+      return cache.add(`${BASE}/`);
     }),
   );
 });
@@ -29,11 +33,14 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
 
-  if (event.request.method !== 'GET' || url.pathname.startsWith('/api/')) {
+  if (
+    event.request.method !== 'GET' ||
+    url.pathname.startsWith(`${BASE}/api/`)
+  ) {
     return;
   }
 
-  const isStaticAsset = url.pathname.startsWith('/_next/static/');
+  const isStaticAsset = url.pathname.startsWith(`${BASE}/_next/static/`);
 
   if (isStaticAsset) {
     event.respondWith(
@@ -65,7 +72,7 @@ self.addEventListener('fetch', (event) => {
           if (cachedResponse) return cachedResponse;
 
           if (event.request.mode === 'navigate') {
-            return caches.match('/');
+            return caches.match(`${BASE}/`);
           }
         });
       }),

--- a/src/app/api/hint-file/route.ts
+++ b/src/app/api/hint-file/route.ts
@@ -12,8 +12,15 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: 'Missing filePath' }, { status: 400 });
   }
 
-  const absPath = path.join(CONTENT_PATH, filePath);
-  if (!fs.existsSync(absPath)) {
+  const absPath = path.resolve(CONTENT_PATH, `.${path.sep}${filePath}`);
+  const rootWithSep = CONTENT_PATH.endsWith(path.sep)
+    ? CONTENT_PATH
+    : `${CONTENT_PATH}${path.sep}`;
+  if (!absPath.startsWith(rootWithSep)) {
+    return NextResponse.json({ error: 'Invalid filePath' }, { status: 400 });
+  }
+
+  if (!fs.existsSync(absPath) || !fs.statSync(absPath).isFile()) {
     return NextResponse.json({ error: 'File not found' }, { status: 404 });
   }
 

--- a/src/app/api/hint-file/route.ts
+++ b/src/app/api/hint-file/route.ts
@@ -20,10 +20,19 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: 'Invalid filePath' }, { status: 400 });
   }
 
-  if (!fs.existsSync(absPath) || !fs.statSync(absPath).isFile()) {
-    return NextResponse.json({ error: 'File not found' }, { status: 404 });
+  // Attempt the read directly rather than checking existence/type first:
+  // a check-then-read sequence is a TOCTOU race. Missing file (ENOENT) and
+  // directory (EISDIR) both map to 404.
+  try {
+    const content = await fs.promises.readFile(absPath, 'utf-8');
+    return NextResponse.json({ content });
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'EISDIR') {
+      return NextResponse.json({ error: 'File not found' }, { status: 404 });
+    }
+    // eslint-disable-next-line no-console
+    console.error('Failed to read hint file:', e);
+    return NextResponse.json({ error: 'Failed to read file' }, { status: 500 });
   }
-
-  const content = fs.readFileSync(absPath, 'utf-8');
-  return NextResponse.json({ content });
 }

--- a/src/app/api/hint-search/route.ts
+++ b/src/app/api/hint-search/route.ts
@@ -5,6 +5,9 @@ import path from 'path';
 const CONTENT_PATH = path.join(process.cwd(), 'src/app/hints');
 
 function walkDir(dir: string, fileList: string[] = []) {
+  if (!fs.existsSync(dir)) {
+    return fileList;
+  }
   const entries = fs.readdirSync(dir, { withFileTypes: true });
   for (const entry of entries) {
     const fullPath = path.join(dir, entry.name);

--- a/src/app/api/hint-tree/route.ts
+++ b/src/app/api/hint-tree/route.ts
@@ -3,6 +3,12 @@ import { NextResponse } from 'next/server';
 import { getHintStructure } from '@/lib/hints';
 
 export async function GET() {
-  const hintStructure = getHintStructure();
-  return NextResponse.json(hintStructure);
+  try {
+    const hintStructure = getHintStructure();
+    return NextResponse.json(hintStructure);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to build hint tree:', e);
+    return NextResponse.json([]);
+  }
 }

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,22 +1,28 @@
 import type { MetadataRoute } from 'next';
 
+import { normalizeBasePath } from '@/lib/basePath';
+
 export default function manifest(): MetadataRoute.Manifest {
+  const basePath = normalizeBasePath(process.env.NEXT_PUBLIC_BASE_PATH);
+
   return {
+    id: `${basePath}/`,
     name: 'ISMD Nástroj',
     short_name: 'ISMD Nástroj',
     description: 'ISMD Nástroj',
-    start_url: '/',
+    start_url: `${basePath}/`,
+    scope: `${basePath}/`,
     display: 'standalone',
     background_color: '#ffffff',
     theme_color: '#000000',
     icons: [
       {
-        src: '/icon-192x192.png',
+        src: `${basePath}/icon-192x192.png`,
         sizes: '192x192',
         type: 'image/png',
       },
       {
-        src: '/icon-512x512.png',
+        src: `${basePath}/icon-512x512.png`,
         sizes: '512x512',
         type: 'image/png',
       },

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -32,12 +32,16 @@ export default function Providers({
 
   useEffect(() => {
     if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
+      // Service worker lives in /public, which Next serves under basePath.
+      // Registering '/sw.js' at root 404s when basePath is set.
       navigator.serviceWorker
-        .register('/sw.js')
+        .register(`${normalizedBasePath}/sw.js`, {
+          scope: `${normalizedBasePath}/`,
+        })
         .then(() => {})
         .catch(() => {});
     }
-  }, []);
+  }, [normalizedBasePath]);
 
   return (
     <ThemeProvider>

--- a/src/lib/hints.ts
+++ b/src/lib/hints.ts
@@ -6,6 +6,10 @@ import { FileNode } from './appTypes';
 const HINTS_PATH = path.join(process.cwd(), 'src/app/hints');
 
 export function getHintStructure(dirPath = HINTS_PATH): FileNode[] {
+  if (!fs.existsSync(dirPath)) {
+    return [];
+  }
+
   const entries = fs.readdirSync(dirPath, { withFileTypes: true });
 
   return entries.map((entry) => {


### PR DESCRIPTION
## Summary
- Fixes PWA asset 404s caused by basePath (`/popisujeme`): the service worker,
  manifest icons, and manifest `start_url`/`scope` were requested at the origin
  root, which Next does not serve under basePath.
- Service worker now registers at `${basePath}/sw.js` with a scoped
  registration; `manifest.ts` resolves icons/`start_url`/`scope`/`id` via the
  existing `normalizeBasePath` helper; `public/sw.js` derives its base from
  `self.registration.scope` so precache, the `/api/` skip, `/_next/static/`
  matching, and the navigate fallback all use the correct prefix.
- Effective in prod: the whole chain (client nginx → AppGW `/popisujeme/*`
  rule → Next) preserves the basePath.
- The root `/favicon.ico` 404 is intentionally left unfixed — a `basePath:false`
  rewrite into the basePath is invalid in Next, and in prod that root request is
  owned by the client nginx edge / AppGW default redirect and never reaches Next.