### PR TITLE
docs: document local-frontend → DEV dev-loop (auth + backend)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,7 +1,32 @@
-NEXT_PUBLIC_BASE_PATH="/popisujeme" # e.g. /popisujeme for subpath deployments, empty for root local run
-BE_URL="http://host.docker.internal:8081/popisujeme" # server-side only, never exposed to client. Use host.docker.internal (not localhost/127.0.0.1) — works whether npm run dev runs in WSL, PowerShell, or Git Bash, and whether the backend is in Docker or IDEA. Linux + Docker Engine only? Use 127.0.0.1 instead.
-KEYCLOAK_CLIENT_ID=""
-KEYCLOAK_CLIENT_SECRET=""
+# Copy to .env.local (gitignored) and fill in. Two supported modes below.
+#
+# ── Mode A: fully local stack (frontend + backend + Keycloak all local) ──
+# ── Mode B: local frontend → DEPLOYED DEV (log in via DEV Keycloak) ──────
+# The values that differ between modes are marked [A] / [B].
+
+NEXT_PUBLIC_BASE_PATH="/popisujeme" # /popisujeme for subpath deploys, empty for root local run
+
+# Backend the /api/backend proxy forwards to (server-side only, never exposed).
+# [A] local backend. Use host.docker.internal (not localhost/127.0.0.1) so it
+#     works from WSL/PowerShell/Git Bash whether the BE is in Docker or IDEA.
+#     (Linux + Docker Engine only? use 127.0.0.1.)
+BE_URL="http://host.docker.internal:8081/popisujeme"
+# [B] deployed DEV backend via the App Gateway's dedicated direct route. DEV
+#     exposes /popisujeme/be/* → backend (the /be prefix is stripped), so a
+#     local frontend can reach the DEV backend directly:
+#     BE_URL="https://oha03.dia.gov.cz/popisujeme/be"
+#     (Only DEV has this route; TEST/PROD backends stay internal-only BFF.)
+
+# Keycloak (the ismd-app client is PUBLIC — secret is ignored by Keycloak; use
+# the same value as the deployed env, or leave blank).
+# [A] local Keycloak realm issuer, e.g. http://localhost:8080/popisujeme/auth/realms/ismd
+# [B] KEYCLOAK_ISSUER="https://oha03.dia.gov.cz/popisujeme/auth/realms/ismd"
 KEYCLOAK_ISSUER=""
+KEYCLOAK_CLIENT_ID="ismd-app"
+KEYCLOAK_CLIENT_SECRET=""
+
+# next-auth base. MUST be localhost for a local run, or login bounces back to
+# the deployed hostname. (DEV Keycloak now allows http://localhost:3000/* as a
+# redirect URI / web origin, so Mode B login works with this value.)
 NEXTAUTH_URL="http://localhost:3000/popisujeme/api/auth"
 NEXTAUTH_SECRET="secret"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,26 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
+## Local frontend, login via deployed DEV Keycloak
+
+You can run the frontend locally and authenticate against the deployed DEV
+Keycloak (useful for UI work without standing up Keycloak locally). Copy
+`.env.local.example` to `.env.local` and use the "Mode B" values:
+
+- `NEXTAUTH_URL="http://localhost:3000/popisujeme/api/auth"` — must be localhost,
+  otherwise login bounces back to the deployed hostname instead of your machine.
+- `KEYCLOAK_ISSUER="https://oha03.dia.gov.cz/popisujeme/auth/realms/ismd"`
+- `KEYCLOAK_CLIENT_ID="ismd-app"` (public client; `KEYCLOAK_CLIENT_SECRET` may be
+  left blank).
+- `BE_URL="https://oha03.dia.gov.cz/popisujeme/be"` — reach the DEV backend
+  directly through the App Gateway's dedicated `/popisujeme/be/*` route.
+
+Both halves work on DEV: the `ismd-app` client allows `http://localhost:3000/*`
+as a redirect URI / web origin (auth), and the App Gateway exposes
+`/popisujeme/be/*` → backend with the `/be` prefix stripped (data). Both are
+configured in terraform and **DEV only** — TEST/PROD trust neither (localhost is
+not allowed, and their backends stay internal-only BFF).
+
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Learn More


### PR DESCRIPTION
## Summary
- Documents the local-frontend → deployed-DEV dev loop in `.env.local.example`
  (Mode A local stack vs Mode B local FE → DEV) and a new README section.
- Auth: `NEXTAUTH_URL` localhost + `KEYCLOAK_ISSUER` = DEV realm — works because the
  DEV `ismd-app` client allows `http://localhost:3000/*` as a redirect URI / web origin.
- Data: `BE_URL=https://oha03.dia.gov.cz/popisujeme/be` — the DEV-only App Gateway
  direct route to the backend (`/be` prefix stripped).
- Docs/config-example only, no app code. Verified end-to-end: a local frontend logs
  into DEV Keycloak and reads DEV data.