### PR TITLE
fix: build tool frontend in production mode and ship blog content

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,45 @@
+# Dependencies — reinstalled inside the image via npm ci
+node_modules
+**/node_modules
+
+# Next.js build output — must be generated fresh inside the image.
+# Copying a host-built (e.g. Windows) .next corrupts the in-image build and
+# causes incremental-build chunk errors (e.g. the bogus "<Html> should not be
+# imported outside of pages/_document" prerender crash).
+.next
+out
+
+# Build/test/coverage artifacts
+coverage
+.nyc_output
+
+# Local env files (secrets stay out of the image)
+.env
+.env.*
+!.env.example
+
+# Git & CI
+.git
+.gitignore
+.github
+
+# Editor / OS cruft
+.vscode
+.idea
+*.swp
+.DS_Store
+Thumbs.db
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Docker / compose
+Dockerfile
+.dockerignore
+docker-compose*.yml
+
+# Misc local-only
+README.md
+*.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@
 FROM node:20-alpine AS build
 WORKDIR /app
 
-# Set environment variable
-ARG NODE_ENV=production
-
 # Copy package files
 COPY package.json package-lock.json* ./
 RUN npm ci --ignore-scripts
@@ -14,7 +11,12 @@ COPY . .
 
 # Build arguments for basePath
 ARG NEXT_PUBLIC_BASE_PATH=/popisujeme
-ENV NODE_ENV=${NODE_ENV}
+# `next build` MUST run in production. Building with NODE_ENV=development
+# produces a broken static export of the error pages and fails with the
+# misleading "<Html> should not be imported outside of pages/_document" error.
+# This is intentionally NOT driven by the NODE_ENV build arg (which may be
+# `development` when composed) — the build is always production.
+ENV NODE_ENV=production
 ENV NEXT_PUBLIC_BASE_PATH=${NEXT_PUBLIC_BASE_PATH}
 
 # Build the application
@@ -43,9 +45,11 @@ COPY --from=build /app/.next ./.next
 COPY --from=build /app/public ./public
 COPY --from=build /app/next.config.ts ./
 COPY --from=build /app/messages ./messages
-# Hint API routes read these markdown files from disk at runtime via
-# process.cwd()/src/app/hints, so the source content must ship in the image.
+# Hint and blog API routes read these markdown/MDX files from disk at runtime
+# via process.cwd()/src/app/{hints,blogs}, so the source content must ship in
+# the image.
 COPY --from=build /app/src/app/hints ./src/app/hints
+COPY --from=build /app/src/app/blogs ./src/app/blogs
 
 EXPOSE 3000
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,9 +8,6 @@ const nextConfig: NextConfig = {
   output: 'standalone',
   basePath,
   pageExtensions: ['ts', 'tsx', 'mdx'],
-  experimental: {
-    mdxRs: true,
-  },
   async rewrites() {
     return [
       // NOTE: the root /favicon.ico 404 (browsers probe the origin root,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@mdx-js/loader": "^3.1.1",
         "@mdx-js/react": "^3.1.1",
-        "@next/mdx": "16.0.6",
+        "@next/mdx": "15.5.7",
         "@swc/helpers": "^0.5.21",
         "@tailwindcss/postcss": "^4.1.17",
         "@tailwindcss/typography": "^0.5.19",
@@ -2010,9 +2010,9 @@
       }
     },
     "node_modules/@next/mdx": {
-      "version": "16.0.6",
-      "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-16.0.6.tgz",
-      "integrity": "sha512-NLWJg4mqYHbHr1uyxFIOVuGFn0ACRA0L/JuL8amr8Pos8ZrRQ1/CUw0rUh22D/kPlq5QOyF/vySl9yvuETmDBA==",
+      "version": "15.5.7",
+      "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-15.5.7.tgz",
+      "integrity": "sha512-ao/NELNlLQkQMkACV0LMimE32DB5z0sqtKL6VbaruVI3LrMw6YMGhNxpSBifxKcgmMBSsIR985mh4CJiqCGcNw==",
       "license": "MIT",
       "dependencies": {
         "source-map": "^0.7.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
-    "@next/mdx": "16.0.6",
+    "@next/mdx": "15.5.7",
     "@swc/helpers": "^0.5.21",
     "@tailwindcss/postcss": "^4.1.17",
     "@tailwindcss/typography": "^0.5.19",


### PR DESCRIPTION
## Summary

`compose.sh up --build tool-fe` failed with a misleading
`<Html> should not be imported outside of pages/_document` error during
/404 prerendering.

The image was building `next build` in **development mode**: compose passes
`NODE_ENV=${NODE_ENV:-development}` as a build arg, the Dockerfile applied it
to the build environment, and `next build` only supports production —
building in development produces a broken static export of Next's internal
error pages. A plain `docker build .` worked only because it used the
Dockerfile's production default and never saw the dev arg.

## Changes

- **Dockerfile**: `next build` now always runs with `NODE_ENV=production`,
  decoupled from the NODE_ENV build arg.
- **Dockerfile**: copy `src/app/blogs` into the runtime image so `/api/blogs`
  reads MDX content at runtime — it previously returned an empty list.
- **.dockerignore**: added; keeps host `node_modules`/`.next` out of the
  build context.
- **@next/mdx**: aligned to `15.5.7` to match `next` (was `16.0.6`).
- **not-found.tsx / global-error.tsx**: custom error pages (polish).

## Notes

This image is a deployable artifact, so a production `next build` is correct;
local frontend development should use `npm run dev`. The compose
`NODE_ENV=development` defaults are misleading and worth cleaning up
separately.